### PR TITLE
Add a gut-update command

### DIFF
--- a/gut-update.sh
+++ b/gut-update.sh
@@ -1,0 +1,20 @@
+# gut-update
+
+GRE="\033[0;32m"
+YEL="\033[0;33m"
+DEF="\033[0;39m"
+
+download () {
+  local file=$1
+  echo -e "${GRE}Downloading: ${YEL}${file}${DEF}"
+  curl -sSL "https://github.com/jareddlc/gut/raw/master/${file}" -o $HOME/${file}
+}
+
+download "gut-color.sh"
+download "gut-git.sh"
+download "gut-kv.sh"
+download "gut-menu.sh"
+download "gut-update.sh"
+download "gut.sh"
+
+echo -e "${GRE}Download complete${DEF}"

--- a/gut-update.sh
+++ b/gut-update.sh
@@ -1,20 +1,23 @@
 # gut-update
 
+# Globals
 GRE="\033[0;32m"
 YEL="\033[0;33m"
 DEF="\033[0;39m"
 
-download () {
-  local file=$1
-  echo -e "${GRE}Downloading: ${YEL}${file}${DEF}"
-  curl -sSL "https://github.com/jareddlc/gut/raw/master/${file}" -o $HOME/${file}
+# Update - Function to update local gut version
+_gut_update() {
+  _gut_update_download "gut-color.sh"
+  _gut_update_download "gut-git.sh"
+  _gut_update_download "gut-kv.sh"
+  _gut_update_download "gut-menu.sh"
+  _gut_update_download "gut-update.sh"
+  _gut_update_download "gut.sh"
+  echo -e "${GRE}Download complete${DEF}"
 }
 
-download "gut-color.sh"
-download "gut-git.sh"
-download "gut-kv.sh"
-download "gut-menu.sh"
-download "gut-update.sh"
-download "gut.sh"
-
-echo -e "${GRE}Download complete${DEF}"
+# Download - Pulls a file directly from GitHub
+_gut_update_download () {
+  echo -e "${GRE}Downloading: ${YEL}$1${DEF}"
+  curl -sSL "https://github.com/jareddlc/gut/raw/master/$1" -o $HOME/$1
+}

--- a/gut.sh
+++ b/gut.sh
@@ -5,6 +5,7 @@ source $HOME/gut-color.sh
 source $HOME/gut-git.sh
 source $HOME/gut-kv.sh
 source $HOME/gut-menu.sh
+source $HOME/gut-update.sh
 
 # Main - Take user input and call the corresponding components
 # Args:
@@ -28,6 +29,8 @@ gut() {
     _gut_push
   elif [ "$1" = "reset" ]; then
     _gut_reset
+  elif [ "$1" = "update" ]; then
+    _gut_update
   else
     echo "[gut] Invalid command"
     _gut_help
@@ -50,6 +53,7 @@ _gut_help() {
   echo "pull          Performs a git pull on the selected remote branch"
   echo "push          Performs a git push on the selected remote branch"
   echo "reset         Performs a git reset --soft to the selected git hash"
+  echo "update        Performs an update to retrieve the latest version of gut"
   echo ""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ install() {
 }
 
 echo -e "${BLU}Installing gut${DEF}"
-curl -sSL "https://github.com/jareddlc/gut/raw/master/gut-update.sh" | sh
+eval "$(curl -sSL "https://github.com/jareddlc/gut/raw/master/gut-update.sh")" && _gut_update
 
 if [ -e "$BASH_PROFILE" ]; then
   install "$BASH_PROFILE"

--- a/install.sh
+++ b/install.sh
@@ -9,13 +9,6 @@ BASH_PROFILE="$HOME/.bash_profile"
 BASH_RC="$HOME/.bashrc"
 GUT_HOME='$HOME/gut.sh'
 
-download() {
-  local fileName=$1
-
-  echo -e "${GRE}Downloading: ${YEL}${fileName}${DEF}"
-  curl -sSL https://github.com/jareddlc/gut/raw/master/${fileName} -o $HOME/${fileName}
-}
-
 install() {
   local dest=$1
   found=$(grep "$GUT_HOME" "$dest")
@@ -33,14 +26,7 @@ install() {
 }
 
 echo -e "${BLU}Installing gut${DEF}"
-
-download "gut-color.sh"
-download "gut-git.sh"
-download "gut-kv.sh"
-download "gut-menu.sh"
-download "gut.sh"
-
-echo -e "${GRE}Download complete${DEF}"
+curl -sSL "https://github.com/jareddlc/gut/raw/master/gut-update.sh" | sh
 
 if [ -e "$BASH_PROFILE" ]; then
   install "$BASH_PROFILE"


### PR DESCRIPTION
This fixes #1.

This will add a new `gut-update` command which will update the local copy of `gut` with the latest from the remote. It also tweaks `install.sh` to piggyback on that command to avoid duplication.